### PR TITLE
Change default wait time

### DIFF
--- a/lib/steps/post-data.js
+++ b/lib/steps/post-data.js
@@ -12,13 +12,13 @@ const postAndWait = async (data) => {
   const result = await axios.post(config.SVARUT_SERVICE_URL, generatePayload(data))
 
   const location = result.headers.location
-  const retryAfter = result.headers['retry-after'] || 10
-  var status = result.status
+  let retryAfter = result.headers['retry-after'] || 3
+  let status = result.status
   logger('info', ['post-data', data._id, 'location', location])
   logger('info', ['post-data', data._id, 'retry-after', retryAfter])
 
-  var retryCount = 1
-  var innerResult
+  let retryCount = 1
+  let innerResult
   while ((status !== 200 && status !== 500) && retryCount < 15) {
     if (status >= 400 && status <= 499) {
       logger('error', ['post-data', data._id, 'error from azf-svarut', status])
@@ -30,6 +30,7 @@ const postAndWait = async (data) => {
 
     innerResult = await axios.get(location)
     status = innerResult.status
+    retryAfter = innerResult.headers['retry-after'] || 10
     logger('info', ['post-data', data._id, 'retry', retryCount, status])
     retryCount++
   }


### PR DESCRIPTION
Change the default retry after to 2 seconds on the first post, then 10 seconds if nothing is defined from the backend. 10 seconds is too long, when the average orchestration time is < 3 seconds.